### PR TITLE
GH-34, GH-36 Add documentation of StrictMode and ExecuteDefault

### DIFF
--- a/docs/.vitepress/sidebar-config.ts
+++ b/docs/.vitepress/sidebar-config.ts
@@ -40,6 +40,8 @@ const vitepressSidebarOptions: VitePressSidebarOptions[] = [
         "root-command.md",
         "priority.md",
         "shortcut.md",
+        "execute-default.md",
+        "strict-mode.md",
 
         "extensions",
 

--- a/docs/documentation/litecommands/features/execute-default.md
+++ b/docs/documentation/litecommands/features/execute-default.md
@@ -1,0 +1,37 @@
+# @ExecuteDefault
+
+The `@ExecuteDefault` annotation in LiteCommands allows you to catch any command execution, if no method is matching 
+the given arguments. 
+
+The `StrictMode` checks the length of the arguments of the command and decides if the method of 
+the annotation gets executed. If it's disabled, the method will always get executed. If it's enabled, 
+LiteCommands will fail the execution with `InvalidUsage.Cause.TOO_MANY_ARGUMENTS`.
+
+## Example Implementation
+
+Here's an example of how to use the `@ExecuteDefault` annotation with a command that sets the game mode:
+
+```java
+@Command(name = "gamemode")
+public class GamemodeCommand {
+    
+    @ExecuteDefault // [!code highlight]
+    public void executeDefault(@Context Player player) {
+        player.sendMessage(ChatUtil.color("&cPlease use one of the following gamemodes:"));
+        player.sendMessage(ChatUtil.color("&c- /gamemode creative"));
+        player.sendMessage(ChatUtil.color("&c- /gamemode survival"));
+    }
+
+    @Execute(name = "creative")
+    public void setCreative(@Context Player player) {
+        player.setGameMode(GameMode.CREATIVE);
+        player.sendMessage(ChatUtil.color("&aGame mode set to Creative."));
+    }
+
+    @Execute(name = "survival")
+    public void setSurvival(@Context Player player) {
+        player.setGameMode(GameMode.SURVIVAL);
+        player.sendMessage(ChatUtil.color("&aGame mode set to Survival."));
+    }
+}
+```

--- a/docs/documentation/litecommands/features/execute-default.md
+++ b/docs/documentation/litecommands/features/execute-default.md
@@ -1,11 +1,7 @@
 # @ExecuteDefault
 
-The `@ExecuteDefault` annotation in LiteCommands allows you to catch any command execution, if no method is matching 
-the given arguments. 
-
-The `StrictMode` checks the length of the arguments of the command and decides if the method of 
-the annotation gets executed. If it's disabled, the method will always get executed. If it's enabled, 
-LiteCommands will fail the execution with `InvalidUsage.Cause.TOO_MANY_ARGUMENTS`.
+The `@ExecuteDefault` annotation in LiteCommands allows you to catch any command execution, if no other method is 
+matching the given arguments. 
 
 ## Example Implementation
 

--- a/docs/documentation/litecommands/features/strict-mode.md
+++ b/docs/documentation/litecommands/features/strict-mode.md
@@ -1,0 +1,64 @@
+# StrictMode
+
+The `StrictMode` enum in LiteCommands decides if methods get executed, even if the argument length
+exceeds the method expected length.
+
+If the `StrictMode` is enabled, LiteCommands checks the length of the given arguments and 
+fails the execution with the reason `InvalidUsage.Cause.TOO_MANY_ARGUMENTS`. 
+This can be caught in your custom `InvalidUsageHandler`.
+
+If the `StrictMode` is disabled, LiteCommands tries to execute any matching method. If no matching
+method is found, the `@ExecuteDefault` will be executed. [See @ExecuteDefault](execute-default.md)
+
+By default, the `StrictMode` is globally enabled, and only the `@ExecuteDefault` annotation disables it.
+
+## Example Implementation
+
+Here's an example of how to change the default `StrictMode`:
+
+```java [Bukkit]
+public class ExamplePlugin extends JavaPlugin {
+
+    private LiteCommands<CommandSender> liteCommands;
+
+    @Override
+    public void onEnable() {
+        this.liteCommands = LiteBukkitFactory.builder("fallback-prefix", this)
+                .commands(
+                        // your commands
+                )
+                .strictMode(StrictMode.DISABLED) // [!code focus]
+                .build();
+    }
+
+    @Override
+    public void onDisable() {
+        if (this.liteCommands != null) {
+            this.liteCommands.unregister();
+        }
+    }
+}
+```
+
+## Changing the StrictMode on commands
+
+You can still change the `StrictMode` in your commands, by changing the `strict` parameter on the following annotations:
+- `@RootCommand` 
+- `@Command` 
+- `@Execute` 
+- `@ExecuteDefault`
+
+```java 
+@Command(name = "hello", strict = StrictMode.DISABLED) // [!code focus]
+public class HelloCommand {
+    @Execute(strict = StrictMode.ENABLED) // [!code focus]
+    void execute() {
+        // /hello
+    }
+}
+```
+
+> [!INFO]
+> If you want to use the global configured `StrictMode`,
+> you need to set the `strict` parameter on the annotations to
+> `StrictMode.DEFAULT`, to let it forward to the global configured value.


### PR DESCRIPTION
This PR adds the documentation of `StrictMode` and `@ExecuteDefault` to the website.

This should close 
- https://github.com/Rollczi/LiteDevelopers-docs/issues/36
- https://github.com/Rollczi/LiteDevelopers-docs/issues/34

Please let me know if something needs to be updated.